### PR TITLE
fix UB with non-volatile local used after longjump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ if ( STATICLIB_TOOLCHAIN MATCHES "android_.+" )
 elseif ( STATICLIB_TOOLCHAIN MATCHES "windows_.+" )
     target_link_libraries ( ${PROJECT_NAME} PRIVATE wtsapi32 )
     set_property ( TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS "/manifest:no" )
+    target_compile_options ( ${PROJECT_NAME} PRIVATE /wd4351 /wd4611 )
 endif ( )
 
 # pkg-config

--- a/src/wiltoncall_pdf.cpp
+++ b/src/wiltoncall_pdf.cpp
@@ -685,7 +685,8 @@ support::buffer draw_image(sl::io::span<const char> data) {
             " please add at least one page to the document first"));
 
     HPDF_Image image = load_image_from_hex(doc, image_hex, format);
-    HPDF_Page_DrawImage(page, image, x, y, width, height);
+    HPDF_Page_DrawImage(page, image, static_cast<HPDF_REAL>(x), static_cast<HPDF_REAL>(y),
+            static_cast<HPDF_REAL>(width), static_cast<HPDF_REAL>(height));
 
     return support::make_empty_buffer();
 }


### PR DESCRIPTION
`auto err_ctx = std::pair<std::jmp_buf, std::string>()` is passed to error callback and in case of error is changed before the longjump - message string is appended and that changes the state of the `std::pair` object itself (at least string length field is changed, that is stored inside it). It is used after the longjump to get an error message from it.

I believe that according to [cppreference](http://en.cppreference.com/w/cpp/utility/program/setjmp) this is UB:

> Upon return to the scope of setjmp, all accessible objects, floating-point status flags, and other components of the abstract machine have the same values as they had when std::longjmp was executed, except for the non-volatile local variables in setjmp's scope, whose values are indeterminate if they have been changed since the setjmp invocation.

Attempts to make `err_ctx` volatile seems to be hard to compile (`volatile` needs to be casted out every time).

Instead, proposed change wraps it into `unique_ptr` (note, there is no `std::make_unique` in C++11).